### PR TITLE
Remove `values` option from `tree()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,8 @@ Numbers within a path are interpreted as an array.
 
 Options include:
   - level: 0 to n - how many levels deep should the traversal go.
-  - values: bool - resolve the values (defaults to false)
 
-`callback` must have the signature `function (err, result)`, where `err` is an Error if the function fails and `result` is an array depending on `options.value`. If it is `true` it is an array of objects containing `path:value` tuples, such as: `[ { '/foo': 'bar' } ...]`. If it is `false` it contains only the paths, such as `['/foo', '/bar', ...]`.
+`callback` must have the signature `function (err, result)`, where `err` is an Error if the function fails and `result` is a list of path such as `["/foo", "/bar", "/author/name", ...]`.
 
 ### Properties
 


### PR DESCRIPTION
If you want the paths as well as the values, call `resolve()` with
the root `/` instead. It will return a nested object containing the
values.

The `values` option also was never part of go-ipld.