### PR TITLE
Major API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,55 +90,6 @@ Possible `options` are:
 This can be used to verify that some data actually has a certain CID.
 
 
-### toJSON(IpldNode)
-
-> Converts an IPLD Node into a JavaScript object that contains only basic types.
-
-Returns a JavaScript object that can be used as input for `JSON.stringify()`. It is *not* a goal to have a JSON representation that is roundtripable back into an IPLD Node. It is meant as a representation that can be processed by third party consumers.
-
-The [IPLD Data Model](https://github.com/ipld/specs/blob/master/IPLD-Data-Model-v1.md) defines two special types that need special attention when converting to JSON:
-  - Binary: the binary data is transformed into a Base64 encoded string.
-  - Links: the links are CID objects. Consumers of this JSON shouldn’t need to have their own CID parsing implementation, hence the CID is provided in its original base encoded format as well as the human readable one.
-
-Example with [dag-cbor](https://github.com/ipld/js-ipld-dag-cbor):
-
-```JavaScript
-'use strict'
-
-const CID = require('cids')
-const ipldDagCbor = require('ipld-dag-cbor')
-
-const input = {
-  binary: Buffer.from('1155fa3c', 'hex'),
-  link: new CID('zdpuAxdeot12gCeKJxANaDAL2juLQDB2QK4PFKnnxdAJLpAZf')
-}
-
-const serialized = await ipldDagCbor.serialize(input)
-const ipldNode = await ipldDagCbor.deserialize(serialized)
-const json = ipldDagCbor.toJSON(ipldNode)
-console.log(JSON.stringify(json, null, 2))
-```
-
-The output is:
-
-```JSON
-{
-  "binary": "EVX6PA==",
-  "link": {
-    "cid": "bafyreifvnutjz6sgkym5cw3fw5e2opfew2gy5dw4wui4tzpphylbmmjsci",
-    "multibase": "base32",
-    "version": 1,
-    "multicodec": "dag-cbor",
-    "multihash": {
-      "name": "sha2-256",
-      "bits": 256,
-      "digest": "b56d269cfa465619d15b65b749a73ca4b68d8e8edcb511c9e5ef3e1616313212"
-    }
-  }
-}
-```
-
-
 ### Properties
 
 #### `defaultHashCode`

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Returns a Promise containing a `Buffer` with the serialized version of the given
 
 The result is a JavaScript object, which may also be a Proxy object in case the data shouldn’t be deserialized as a whole. Its fields are the public API that can be resolved through. It’s up to the format to add convenient methods for manipulating the data. The returned object may also be a Proxy object in case the data shouldn’t be deserialized as a whole.
 
+All enumerable properties (the ones that are returned by a `Object.keys()` call) of the deserialized object are considered for resolving IPLD Paths. They must only return values whose type is one of the [IPLD Data Model](https://github.com/ipld/specs/blob/master/IPLD-Data-Model-v1.md).
+
 Returns a Promise containing the Javascript object. This object must be able to be serialized with a `serialize()` call.
 
 

--- a/README.md
+++ b/README.md
@@ -14,16 +14,12 @@
   - [Badge](#badge)
 - [Definitions](#definitions)
 - [API](#api)
-  - [IPLD format utils](#ipld-format-utils)
-    - [`util.serialize(dagNode, callback)`](#utilserializedagnode-callback)
-    - [`util.deserialize(binaryBlob, callback)`](#utildeserializebinaryblob-callback)
-    - [`util.cid(binaryBlob[, options], callback)`](#utilcidbinaryblob-options-callback)
-  - [Local resolver methods](#local-resolver-methods)
-    - [`resolver.resolve(binaryBlob, path, callback)`](#resolverresolvebinaryblob-path-callback)
-    - [`resolver.tree(binaryBlob, callback)`](#resolvertreebinaryblob-callback)
+  - [`serialize(IpldNode)`](#serializeipldnode)
+  - [`deserialize(binaryBlob)`](#deserializebinaryblob)
+  - [`cid(binaryBlob, [options])`](#cidbinaryblob-options)
   - [Properties](#properties)
     - [`defaultHashAlg`](#defaulthashalg)
-    - [`multicodec`](#multicodec)
+    - [`format`](#format)
 - [Maintainers](#maintainers)
 - [Contribute](#contribute)
 - [License](#license)
@@ -61,7 +57,7 @@ A valid (read: that follows this interface) IPLD format implementation the follo
 IPLD Format APIs are restricted to a single IPLD Node, they never access any linked IPLD Nodes.
 
 
-### serialize(IpldNode)
+### `serialize(IpldNode)`
 
 > Serializes the internal representation of an IPLD Node into a binary blob.
 
@@ -70,7 +66,7 @@ IPLD Format APIs are restricted to a single IPLD Node, they never access any lin
 Returns a Promise containing a `Buffer` with the serialized version of the given IPLD Node.
 
 
-### deserialize(binaryBlob)
+### `deserialize(binaryBlob)`
 
 > Deserialize into internal representation.
 
@@ -79,7 +75,7 @@ The result is a JavaScript object, which may also be a Proxy object in case the 
 Returns a Promise containing the Javascript object. This object must be able to be serialized with a `serialize()` call.
 
 
-### cid(binaryBlob, [options])
+### `cid(binaryBlob, [options])`
 
 > Return the CID of the binary blob.
 

--- a/README.md
+++ b/README.md
@@ -92,17 +92,17 @@ This can be used to verify that some data actually has a certain CID.
 
 ### Properties
 
-#### `defaultHashCode`
+#### `defaultHashAlg`
 
 > Default hash algorithm of the format,
 
-Most formats have one specific hash algorithm, e.g. Bitcoin’s is `dbl-sha2-256`. CBOR can be used with any hash algorithm, though the default in the IPFS world is `sha256`. `defaultHashAlg` is used in the `cid()` call if no hash algorithm is given. The value of `defaultHashAlg` must be one code defined in the [Multihash Table](https://github.com/multiformats/multihash#table-for-multihash).
+Most formats have one specific hash algorithm, e.g. Bitcoin’s is `dbl-sha2-256`. CBOR can be used with any hash algorithm, though the default in the IPFS world is `sha256`. `defaultHashAlg` is used in the `cid()` call if no hash algorithm is given. The value of `defaultHashAlg` is of type `Multicodec` must be one code defined in the [Multihash Table](https://github.com/multiformats/multihash#table-for-multihash).
 
-#### `codec`
+#### `format`
 
 > Identifier for the format implementation.
 
-The `codec` property is used to register a format implementation in IPLD. It needs to be one of the codes specified in the [Multicodec Table](https://github.com/multiformats/multicodec#multicodec-table).
+The `format` property of type `Multicodec` is used to register a format implementation in IPLD. It needs to be one of the codes specified in the [Multicodec Table](https://github.com/multiformats/multicodec#multicodec-table).
 
 
 ## Maintainers

--- a/README.md
+++ b/README.md
@@ -92,13 +92,13 @@ This can be used to verify that some data actually has a certain CID.
 
 > Default hash algorithm of the format,
 
-Most formats have one specific hash algorithm, e.g. Bitcoin’s is `dbl-sha2-256`. CBOR can be used with any hash algorithm, though the default in the IPFS world is `sha256`. `defaultHashAlg` is used in the `cid()` call if no hash algorithm is given. The value of `defaultHashAlg` is of type `Multicodec` must be one code defined in the [Multihash Table](https://github.com/multiformats/multihash#table-for-multihash).
+Most formats have one specific hash algorithm, e.g. Bitcoin’s is `dbl-sha2-256`. CBOR can be used with any hash algorithm, though the default in the IPFS world is `sha256`. `defaultHashAlg` is used in the `cid()` call if no hash algorithm is given. The value of `defaultHashAlg` is of type `Multicodec` should be one code defined in the [Multihash Table](https://github.com/multiformats/multihash#table-for-multihash).
 
 #### `format`
 
 > Identifier for the format implementation.
 
-The `format` property of type `Multicodec` is used to register a format implementation in IPLD. It needs to be one of the codes specified in the [Multicodec Table](https://github.com/multiformats/multicodec#multicodec-table).
+The `format` property of type `Multicodec` is used to register a format implementation in IPLD. It should be one of the codes specified in the [Multicodec Table](https://github.com/multiformats/multicodec#multicodec-table).
 
 
 ## Maintainers

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Include this badge in your readme if you make a new module that implements inter
 
 ## Definitions
 
-- **dagNode**: The implementation specific representation of a deserialized block.
+- **dagNode**: The implementation specific representation of a deserialized blob.
 
 ## API
 
@@ -61,7 +61,7 @@ IPLD Format APIs are restricted to a single IPLD Node, they never access any lin
 
 > Serializes the internal representation of an IPLD Node into a binary blob.
 
-`IpldNode` is a previously deserialized binary Block.
+`IpldNode` is a previously deserialized binary blob.
 
 Returns a Promise containing a `Buffer` with the serialized version of the given IPLD Node.
 

--- a/README.md
+++ b/README.md
@@ -77,13 +77,15 @@ Returns a Promise containing the Javascript object. This object must be able to 
 
 ### `cid(binaryBlob, [options])`
 
-> Return the CID of the binary blob.
+> Calculate the CID of the binary blob.
 
 Possible `options` are:
   - `version` (`number`, default: 1): the CID version to be used
   - `hashAlg` (`Multicodec`, default: the one the format specifies): the hash algorithm to be used
 
 This can be used to verify that some data actually has a certain CID.
+
+Returns a Promise containing the calculated CID of the given binary blob.
 
 
 ### Properties


### PR DESCRIPTION
The whole IPLD APIs get a review to make them more consistent and
easier to use.

The biggest change is that there's not `resolve` API anymore. From
now on you access the properties of the JavaScript objects directly.

Issues that were taken into account:

 - https://github.com/ipld/interface-ipld-format/issues/31
   - [x] Remove `isLink()` method from formats: `isLink()` is no
         longer needed as all links will be CID objects you can easily
         check for
 - https://github.com/ipld/interface-ipld-format/issues/44
   - [x] Proposal: Move resolver to use CID instances for links: Not
         applicable anymore as `resolve.resolve()` is removed
 - https://github.com/ipld/interface-ipld-format/issues/46
   - [x] properties: align spec with implementation: Covered by spec
 - https://github.com/ipld/interface-ipld-format/issues/49
   - [x] Define how `toJSON()` should look like: Binary and CIDs are
         defined with example
 - https://github.com/ipld/interface-ipld-format/issues/34
   - [x] Implementation of nested objects: Won’t fix as `tree()` is
         not part of the API anymore

Closes #48.